### PR TITLE
Remove "Server" header

### DIFF
--- a/templates/caddyfile.j2
+++ b/templates/caddyfile.j2
@@ -18,10 +18,27 @@ https://{{ domain }} {
   root * /srv
   file_server
 {% endif %}
+  header {
+    -Server
+  }
+  handle_errors {
+    header {
+      -Server
+    }
+  }
 }
 http://{{ domain }} {
   bind 0.0.0.0
   redir https://{host}{uri} permanent
+
+  header {
+    -Server
+  }
+  handle_errors {
+    header {
+      -Server
+    }
+  }
 }
 :4123 {
         tls internal

--- a/templates_for_script/caddy
+++ b/templates_for_script/caddy
@@ -13,10 +13,29 @@
 }
 https://$VLESS_DOMAIN {
         $CADDY_REVERSE
+
+        header  {
+                -Server
+        }
+        handle_errors {
+                header {
+                        -Server
+                }
+        }
 }
 http://$VLESS_DOMAIN {
         bind 0.0.0.0
         redir https://$VLESS_DOMAIN{uri} permanent
+
+        header {
+                -Server
+        }
+
+        handle_errors {
+                header {
+                        -Server
+                }
+        }
 }
 :4123 {
         tls internal


### PR DESCRIPTION
В текущей конфигурации Caddy отдает заголовоки Server со значениями uvicorn (если используется marzban) и Caddy:
<img width="956" height="409" alt="image" src="https://github.com/user-attachments/assets/d11deea7-4a3a-4fdd-aad7-cabd845ecd6f" />
Это может выглядеть подозрительно, так как confluence не работает на python.
Эти заголовки можно отключить в конфигурации Caddy, что я рекомендую сделать. Вот результат:
<img width="548" height="277" alt="image" src="https://github.com/user-attachments/assets/1baf4874-5f32-4322-a0d3-39d162b5ded2" />
Вряд-ли конечно ркн будет на это смотреть, но лишним точно не будет.